### PR TITLE
Fix a broken formula

### DIFF
--- a/_data/functions.yml
+++ b/_data/functions.yml
@@ -13,7 +13,7 @@
     call: DAYS('3/15/11', '2/1/11')
     result: '42'
   - title: DAYS360
-    call: DAYS360('1-Jan-11', '31-Dec-11')
+    call: DAYS360('1-Jan-11', '31-Dec-11', false)
     result: '360'
   - title: EDATE
     call: EDATE('1/15/11', -1)


### PR DESCRIPTION
## Problem

The `DAYS360` example results in an error.

![image](https://user-images.githubusercontent.com/5052422/143776102-cea80e62-126d-4211-bb7d-0558230c1ace.png)



## Solution

`DAYS360` expects a 3rd boolean argument. By providing a value for the argument, the error goes away.

![image](https://user-images.githubusercontent.com/5052422/143776135-bf70ddf6-e5a7-45f1-b907-fb66bc0ddace.png)


**`DAYS360` Source**: 
 https://github.com/sutoiku/formula.js/blob/f52b7efd424036fdd708c9de3ac501f41d595d8c/lib/date-time.js#L114-L150

