### PR TITLE
update formula.js version

### DIFF
--- a/functions.html
+++ b/functions.html
@@ -44,7 +44,7 @@ navigation: main
 </div>
 {%- endfor -%}
 <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.2/dist/jstat.min.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/formulajs/formulajs@2.6.9/dist/formula.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/formulajs/formulajs@2.9.2/dist/formula.min.js"></script>
 <script>
 
     $('.function').each((index, component) => {

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ Powered by [jsDelivr](https://www.jsdelivr.com/), you can use the latest version
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.2/dist/jstat.min.js"></script> 
-<script src="https://cdn.jsdelivr.net/gh/formulajs/formulajs@2.5.0/dist/formula.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/formulajs/formulajs@2.9.2/dist/formula.min.js"></script>
 ```
 
 ### In node


### PR DESCRIPTION
Hi, since some behavior changed since v2.6.9 it would be nice to have the current implementation on the documentation website. 
Note that I don't know the etiquette for this. If you want me to open an Issue or change something in the PR, just let me know.

Off-topic:
Also I wanted to clarify if it is wanted, that FIND() returns a #VALUE! error when find_text is not found in within_text, because the release notes for 2.8.0 are not really clear on this.